### PR TITLE
Replace u16 and u32 parser with generic implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ chrono = "0.4"
 uuid = { version = "1.0", feature = ["v4"] }
 md5 = { version = "0.7" }
 eui48 = "1.1"
+num = "0.4"


### PR DESCRIPTION
Use the num crate to implement a generic implementation for the u16 and
u32 parser. The num::Unsigned trait can be used to limit the generic to
only apply to numbers which are unsigned. And thus implement
from_str_radix().

Also we limit T further to only apply to types where FromstrRadixErr is
ParseIntError. Thus leavs our implementation only for unsigned integers.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>