### PR TITLE
Introduce an optional comment property to gpios

### DIFF
--- a/docs/eep.schema
+++ b/docs/eep.schema
@@ -104,6 +104,10 @@
                                 "pull": {
                                     "description": "Pull resistor setting for this gpio",
                                     "enum": [ "default", "up", "down", "none" ]
+                                },
+                                "comment": {
+                                    "description": "An optional comment describing the function of this gpio",
+                                    "type": "string"
                                 }
                             }
                         }

--- a/docs/example.json
+++ b/docs/example.json
@@ -25,7 +25,8 @@
                 {
                     "gpio": 4,
                     "fsel": "alt1",
-                    "pull": "up"
+                    "pull": "up",
+                    "comment": "This configures the I2C1 SCL"
                 }
             ]
         }

--- a/revpi-hat-eep/src/gpio.rs
+++ b/revpi-hat-eep/src/gpio.rs
@@ -231,12 +231,13 @@ impl From<GpioPull> for gpio_map::GpioPull {
 /// leavs only the first 28 gpios. The gpios 0 and 1 are used for the HAT EEPROM
 /// and should not be changed. The gpio bank validation will not allow to modify
 /// the gpios 0 and 1 also the gpios higher then 27.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GpioPin {
     gpio: u8,
     fsel: GpioFsel,
     pull: GpioPull,
+    comment: Option<String>,
 }
 
 /// This struct represents the GPIO configuration of the HAT EEPROM


### PR DESCRIPTION
The json format now allows an optinal "comment" property on every gpio. This can be used to decribe the function of the pin and why the setting is done.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>