### PR TITLE
revpi-eep: Use now().date_naive() instead of today().naive_local()

### DIFF
--- a/revpi-hat-eep/src/bin/revpi-eep.rs
+++ b/revpi-hat-eep/src/bin/revpi-eep.rs
@@ -238,7 +238,7 @@ fn main() {
     } else if let Some(edate_config) = config.edate {
         edate_config
     } else {
-        chrono::Local::today().naive_local()
+        chrono::Local::now().date_naive()
     };
 
     let mac = if let Some(mac_cli) =  cli.mac {


### PR DESCRIPTION
The chrono crate deprecated the use of Local::today() with 0.4.23. The replacment is Local::now() (available since chrono 0.4.20).

Replace Local::today().naive_local() with Local::now().date_naive().

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>