### PR TITLE
Add multi-line support to gpios in the json config

### DIFF
--- a/docs/eep.schema
+++ b/docs/eep.schema
@@ -106,8 +106,11 @@
                                     "enum": [ "default", "up", "down", "none" ]
                                 },
                                 "comment": {
-                                    "description": "An optional comment describing the function of this gpio",
-                                    "type": "string"
+                                    "type": "array",
+                                    "items": {
+                                        "description": "An optional comment describing the function of this gpio",
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }

--- a/docs/example.json
+++ b/docs/example.json
@@ -26,7 +26,10 @@
                     "gpio": 4,
                     "fsel": "alt1",
                     "pull": "up",
-                    "comment": "This configures the I2C1 SCL"
+                    "comment": [
+                        "This configures the I2C1 SCL",
+                        "external pull-up missing"
+                    ]
                 }
             ]
         }

--- a/revpi-hat-eep/src/bin/revpi-eep.rs
+++ b/revpi-hat-eep/src/bin/revpi-eep.rs
@@ -238,7 +238,7 @@ fn main() {
     } else if let Some(edate_config) = config.edate {
         edate_config
     } else {
-        chrono::Local::today().naive_local()
+        chrono::Local::now().date_naive()
     };
 
     let mac = if let Some(mac_cli) =  cli.mac {

--- a/revpi-hat-eep/src/gpio.rs
+++ b/revpi-hat-eep/src/gpio.rs
@@ -237,7 +237,8 @@ pub struct GpioPin {
     gpio: u8,
     fsel: GpioFsel,
     pull: GpioPull,
-    comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    comment: Option<Vec<String>>,
 }
 
 /// This struct represents the GPIO configuration of the HAT EEPROM


### PR DESCRIPTION
* Replace the deprecated chrono::Local::today() function
* Add some kine of multi-line support to gpios in the json config.