### PR TITLE
revpi-hat-eep: Implement EEPROM Data Version

### DIFF
--- a/docs/JSON-Format.md
+++ b/docs/JSON-Format.md
@@ -15,6 +15,7 @@ _gpiobanks_ describes settings for a gpio bank of the SoC. At the moment only ba
 ```json
 {
     "version": 1,
+    "eeprom_data_version": 3,
     "vstr": "Kunbus GmbH",
     "pstr": "RevPi MiniXL",
     "pid": 642,
@@ -55,6 +56,7 @@ All fields are mandatory.
 | Field     | JSON Datatype             | Range       | Description | Example  |
 |:----------|:--------------------------|:------------|:------------|:---------|
 | version   | number                    | u16         | Version of the EEPROM format | 1 |
+| eeprom_data_version | number           | u16         | Version of the EEPROM content | 3 |
 | vstr      | string                    | 255&#160;chars | Vendor of the device | KUNBUS&#160;GmbH  |
 | pstr      | string                    | 255&#160;chars | Product name         | RevPi&#160;MiniXL |
 | pid       | number                    | u16         | Product identification number | 42 |

--- a/docs/eep.schema
+++ b/docs/eep.schema
@@ -13,6 +13,12 @@
             "minimum": 0,
             "maximum": 65535
         },
+        "eeprom_data_version": {
+            "description": "Version of the EEPROM content",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+        },
         "vstr": {
             "description": "Vendor string",
             "type": "string",

--- a/docs/example.json
+++ b/docs/example.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 3,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi ExampleDevice 8GB",
     "pid": 666,

--- a/revpi-hat-eep/src/bin/revpi-eep.rs
+++ b/revpi-hat-eep/src/bin/revpi-eep.rs
@@ -108,6 +108,9 @@ fn create_rpi_eep(config: RevPiHatEeprom) -> Result<rpi_hat_eep::Eep, Box<dyn st
     let data = EepAtomCustomData::new(config.version.to_string().into_bytes());
     eep.push(EepAtom::new_custom(data))?;
 
+    let data = EepAtomCustomData::new(config.eeprom_data_version.to_string().into_bytes());
+    eep.push(EepAtom::new_custom(data))?;
+
     let data = EepAtomCustomData::new(serial.to_string().into_bytes());
     eep.push(EepAtom::new_custom(data))?;
 

--- a/revpi-hat-eep/src/lib.rs
+++ b/revpi-hat-eep/src/lib.rs
@@ -30,6 +30,7 @@ impl std::fmt::Display for ValidationError {
 /// ```json
 /// {
 ///     "version": 1,
+///     "eeprom_data_version": 3,
 ///     "vstr": "KUNBUS GmbH",
 ///     "pstr": "RevPi ExampleDevice 8GB",
 ///     "pid": 666,
@@ -88,6 +89,8 @@ impl std::fmt::Display for ValidationError {
 pub struct RevPiHatEeprom {
     /// The version of the used [RevPi HAT EEPROM Format](https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#0-format-version)
     pub version: u16,
+    /// The version of the HAT EEPROM content (16 bits) see [EEPROM Data Version](https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#6-eeprom-data-version)
+    pub eeprom_data_version: u16,
     /// The vendor string (max. 255 chars (bytes)), see [Vendor String](https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#vendor-string-vstr)
     pub vstr: String,
     /// The product string (max. 255 chars (bytes)), see [Product String](https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#product-string-pstr)


### PR DESCRIPTION
The EEPROM Data Version is an attribute in the RevPi HAT EEPROM Format. It is used to track changes to the content of the EEPROM of a product. https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#6-eeprom-data-version

This implements the EEPROM Data Version in the json format and the revpi-eep tool.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>