### PR TITLE
doc: reflect gpiobank requirement in schema

### DIFF
--- a/docs/eep.schema
+++ b/docs/eep.schema
@@ -68,8 +68,9 @@
             "pattern": "^([A-F0-9]{2}[-:]){5}[A-F0-9]{2}$"
         },
         "gpiobanks": {
-            "description": "GPIOBank configuration (only bank 0 is supported at the moment)",
+            "description": "GPIOBank configuration, supports bank0 (mandatory) and bank1",
             "type": "array",
+            "minItems": 1,
             "maxItems": 2,
             "items": {
                 "type": "object",


### PR DESCRIPTION
The crate revpi-hat-eep throws an error, if none or more than two gpiobanks are defined in an input JSON file. Reflect those requirements in the JSON schema file.

Signed-off-by: Frank Erdrich <f.erdrich@kunbus.com>